### PR TITLE
Fix "Sign Up" button redirect link

### DIFF
--- a/src/app/events/events.component.html
+++ b/src/app/events/events.component.html
@@ -153,7 +153,7 @@
                 <span class="time">11:00 AM (SAT) - 2:00 PM (SUN)</span>
               </span>
             </div>
-            <a class="event-sign-up-button" routerLink="/events/xiv">Sign Up</a>
+            <a class="event-sign-up-button" routerLink="/events/xv">Sign Up</a>
           </div>
         </div>
   


### PR DESCRIPTION
Fixed an issue where the "Sign Up" button in the Upcoming Events section would lead to the previous Hack Upstate event. It now redirects to the Hack Upstate XV event page.